### PR TITLE
Fixed how-tos & recipes not being displayed on homepage in production

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -198,15 +198,11 @@ export async function getStaticPaths() {
 
   const homepagePages = getPages(homepage, (page, { locale }) => ({
     type: "homepage",
-    posts:
-      locale &&
-      (!shouldDisplayExperimentals()
-        ? getPosts(blogs, locale)
-        : [
-            ...getPosts(blogs, locale),
-            ...getPosts(howTos, locale),
-            ...getPosts(recipes, locale),
-          ]),
+    posts: locale && [
+      ...getPosts(blogs, locale),
+      ...getPosts(howTos, locale),
+      ...getPosts(recipes, locale),
+    ],
   }));
 
   const cartPages = getPages(cart, () => ({


### PR DESCRIPTION
Fixed how-tos & recipes not being displayed on homepage in production.