### PR TITLE
Fixed single CMS error not being caught

### DIFF
--- a/src/store/CMS.js
+++ b/src/store/CMS.js
@@ -88,19 +88,14 @@ async function catchError(error) {
       "error",
       "Failed to fetch data from CMS, serving from the cache"
     );
-  } else
+  } else {
     printMessage(
       "error",
       "Failed to fetch data from CMS, nothing found in cache!"
     );
-
-  if (error.message) {
-    try {
-      throw error;
-    } catch (error) {}
-  } else {
-    console.error(error);
   }
+
+  console.error(error);
 
   return cachedData;
 }


### PR DESCRIPTION
Fixed error not being caught if there's only one error coming from the CMS when trying to fetch data.