### PR TITLE
fix: #250 and #249

### DIFF
--- a/src/components/scripts/ChaptersFunctionality.astro
+++ b/src/components/scripts/ChaptersFunctionality.astro
@@ -149,8 +149,8 @@
           if (window.innerWidth < 640) {
             const isFirstHeadingLink = firstHeadingID === headingID;
 
-            stickyHeadingLinksContainer.classList.add("hidden");
-
+            stickyHeadingLinksContainer.parentElement.classList.add("hidden");
+            
             const navbarHeight = navbar.getBoundingClientRect().height,
               stickyHeaderHeight = stickyHeader.getBoundingClientRect().height;
 


### PR DESCRIPTION
- navlinks don't disappear after clicking on one of them
- the sticky bar hides after clicking a link