### PR TITLE
Disabled OpenReplay to fix the SIGSEGV error

### DIFF
--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -109,8 +109,11 @@ const openGraphImage =
   )
 }
 
+{
+  /* currently OpenReplay is disabled due to causing SIGSEGV (Aw Snap!) errors on Linux & Android */
+}
 {/* OpenReplay Tracking Code for Dilmahtea.me */}
-<script>
+<!-- <script>
   window.addEventListener("load", () => {
     var initOpts = {
       projectKey: "IjHJ0NTxwL2YHDk9TDnR",
@@ -163,4 +166,4 @@ const openGraphImage =
       startOpts
     );
   });
-</script>
+</script> -->


### PR DESCRIPTION
Disabled OpenReplay to fix the SIGSEGV (Aw Snap!) error happening on Chromium-based browsers.