### PR TITLE
Save filters per session instead of permanently

### DIFF
--- a/src/components/solid/ProductFiltersForm.tsx
+++ b/src/components/solid/ProductFiltersForm.tsx
@@ -26,7 +26,7 @@ export default function ProductFiltersForm({
   function updateProductFilters(event) {
     const filters = Object.fromEntries(new FormData(this));
 
-    localStorage.setItem("preferredFilters", JSON.stringify(filters));
+    sessionStorage.setItem("preferredFilters", JSON.stringify(filters));
 
     setProductFilters(filters);
 

--- a/src/store/signals/productFilters.ts
+++ b/src/store/signals/productFilters.ts
@@ -6,7 +6,11 @@ declare interface ProductFilters {
 }
 
 const [productFilters, setProductFilters] = createSignal<ProductFilters>(
-  JSON.parse(localStorage.getItem("preferredFilters") || "{}")
+  JSON.parse(
+    (typeof window !== "undefined" &&
+      window.sessionStorage.getItem("preferredFilters")) ||
+      "{}"
+  )
 );
 
 export { productFilters, setProductFilters };


### PR DESCRIPTION
Save preferred product filters per session instead of permanently.